### PR TITLE
Extend nephron options

### DIFF
--- a/main/src/main/java/org/opennms/nephron/NephronOptions.java
+++ b/main/src/main/java/org/opennms/nephron/NephronOptions.java
@@ -138,4 +138,27 @@ public interface NephronOptions extends PipelineOptions {
 
     void setAllowedLatenessMs(long value);
 
+    @Description("Elasticsearch Connection Timeout in milliseconds")
+    @Default.Integer(30 * 1000) // 30 seconds
+    int getElasticConnectTimeout();
+
+    void setElasticConnectTimeout(int value);
+
+    @Description("Elasticsearch Socket Timeout in milliseconds")
+    @Default.Integer(30 * 1000) // 30 seconds
+    int getElasticSocketTimeout();
+
+    void setElasticSocketTimeout(int value);
+
+    @Description("Elasticsearch Retry Count")
+    @Default.Integer(3) // 3 Retries
+    int getElasticRetryCount();
+
+    void setElasticRetryCount(int value);
+
+    @Description("Elasticsearch Retry Duration")
+    @Default.Long(3 * 1000L) // 3 Seconds
+    long getElasticRetryDuration();
+
+    void setElasticRetryDuration(long value);
 }

--- a/main/src/main/java/org/opennms/nephron/Pipeline.java
+++ b/main/src/main/java/org/opennms/nephron/Pipeline.java
@@ -312,8 +312,8 @@ public class Pipeline {
         private long elasticRetryDuration;
 
         public WriteToElasticsearch(String elasticUrl, String elasticUser, String elasticPassword, String elasticIndex,
-                                    IndexStrategy indexStrategy, int elasticConnectTimeout,
-                                    int elasticSocketTimeout) {
+                                    IndexStrategy indexStrategy, int elasticConnectTimeout, int elasticSocketTimeout,
+                                    int elasticRetryCount, long elasticRetryDuration) {
             Objects.requireNonNull(elasticUrl);
             this.elasticIndex = Objects.requireNonNull(elasticIndex);
             this.indexStrategy = Objects.requireNonNull(indexStrategy);
@@ -326,14 +326,15 @@ public class Pipeline {
             thisEsConfig = thisEsConfig.withConnectTimeout(elasticConnectTimeout)
                                        .withSocketTimeout(elasticSocketTimeout);
             this.esConfig = thisEsConfig;
+            this.elasticRetryCount = elasticRetryCount;
+            this.elasticRetryDuration = elasticRetryDuration;
         }
 
         public WriteToElasticsearch(NephronOptions options) {
             this(options.getElasticUrl(), options.getElasticUser(), options.getElasticPassword(),
                     options.getElasticFlowIndex(), options.getElasticIndexStrategy(),
-                    options.getElasticConnectTimeout(), options.getElasticSocketTimeout());
-            this.elasticRetryCount = options.getElasticRetryCount();
-            this.elasticRetryDuration = options.getElasticRetryDuration();
+                    options.getElasticConnectTimeout(), options.getElasticSocketTimeout(),
+                    options.getElasticRetryCount(), options.getElasticRetryDuration());
         }
 
         @Override

--- a/main/src/main/java/org/opennms/nephron/Pipeline.java
+++ b/main/src/main/java/org/opennms/nephron/Pipeline.java
@@ -308,7 +308,12 @@ public class Pipeline {
         private final Counter flowsToEs = Metrics.counter("flows", "to_es");
         private final Distribution flowsToEsDrift = Metrics.distribution("flows", "to_es_drift");
 
-        public WriteToElasticsearch(String elasticUrl, String elasticUser, String elasticPassword, String elasticIndex, IndexStrategy indexStrategy) {
+        private int elasticRetryCount;
+        private long elasticRetryDuration;
+
+        public WriteToElasticsearch(String elasticUrl, String elasticUser, String elasticPassword, String elasticIndex,
+                                    IndexStrategy indexStrategy, int elasticConnectTimeout,
+                                    int elasticSocketTimeout) {
             Objects.requireNonNull(elasticUrl);
             this.elasticIndex = Objects.requireNonNull(elasticIndex);
             this.indexStrategy = Objects.requireNonNull(indexStrategy);
@@ -318,17 +323,27 @@ public class Pipeline {
             if (!Strings.isNullOrEmpty(elasticUser) && !Strings.isNullOrEmpty(elasticPassword)) {
                 thisEsConfig = thisEsConfig.withUsername(elasticUser).withPassword(elasticPassword);
             }
+            thisEsConfig = thisEsConfig.withConnectTimeout(elasticConnectTimeout)
+                                       .withSocketTimeout(elasticSocketTimeout);
             this.esConfig = thisEsConfig;
         }
 
         public WriteToElasticsearch(NephronOptions options) {
-            this(options.getElasticUrl(), options.getElasticUser(), options.getElasticPassword(), options.getElasticFlowIndex(), options.getElasticIndexStrategy());
+            this(options.getElasticUrl(), options.getElasticUser(), options.getElasticPassword(),
+                    options.getElasticFlowIndex(), options.getElasticIndexStrategy(),
+                    options.getElasticConnectTimeout(), options.getElasticSocketTimeout());
+            this.elasticRetryCount = options.getElasticRetryCount();
+            this.elasticRetryDuration = options.getElasticRetryDuration();
         }
 
         @Override
         public PDone expand(PCollection<FlowSummary> input) {
             return input.apply("SerializeToJson", toJson())
                     .apply("WriteToElasticsearch", ElasticsearchIO.write().withConnectionConfiguration(esConfig)
+                            .withRetryConfiguration(
+                                    ElasticsearchIO.RetryConfiguration.create(this.elasticRetryCount,
+                                            Duration.millis(this.elasticRetryDuration))
+                            )
                             .withUsePartialUpdate(true)
                             .withIndexFn(new ElasticsearchIO.Write.FieldValueExtractFn() {
                                 @Override


### PR DESCRIPTION
Extend Nephron options to include additional Elasticsearch socket/connect timeout parameters and utilize Elasticsearch retry count and duration options.