### PR TITLE
Fix CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,8 +1,9 @@
-version: 2
+version: 2.1
 
 jobs:
   build:
-    machine: true
+    machine:
+      image: ubuntu-2004:202010-01
 
     environment:
       MAVEN_OPTS: -Xmx1024m
@@ -61,7 +62,8 @@ jobs:
             - project
 
   deploy:
-    machine: true
+    docker:
+      - image: maven:3-openjdk-11
 
     steps:
       - attach_workspace:

--- a/pom.xml
+++ b/pom.xml
@@ -246,22 +246,6 @@
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-javadoc-plugin</artifactId>
-                <version>3.0.1</version>
-                <executions>
-                    <execution>
-                        <id>attach-javadocs</id>
-                        <goals>
-                            <goal>jar</goal>
-                        </goals>
-                        <configuration>
-                            <additionalaram>${javadoc.opts}</additionalaram>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-release-plugin</artifactId>
                 <version>2.5.3</version>
                 <configuration>


### PR DESCRIPTION
Requiring Java 11 has broken the CI build. This updates the machine used for building to make Java 11 available.