### PR TITLE
WIP: use deltaSwitched instead of lastSwitched as initial event time

### DIFF
--- a/main/pom.xml
+++ b/main/pom.xml
@@ -145,13 +145,13 @@
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-slf4j-impl</artifactId>
             <version>${log4j.version}</version>
-            <scope>test</scope>
+<!--            <scope>test</scope>-->
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
             <version>${log4j.version}</version>
-            <scope>test</scope>
+<!--            <scope>test</scope>-->
         </dependency>
     </dependencies>
 

--- a/main/src/main/java/org/opennms/nephron/NephronOptions.java
+++ b/main/src/main/java/org/opennms/nephron/NephronOptions.java
@@ -117,13 +117,6 @@ public interface NephronOptions extends PipelineOptions {
 
     void setDefaultMaxInputDelayMs(long value);
 
-    @Description("Max amount of time a flow is expected to last (last_switched - delta_switched). " +
-            "Flows that last longer than this duration will be ignored and a warning will be logged.")
-    @Default.Long(15 * 60 * 1000L) // 15 minutes
-    long getMaxFlowDurationMs();
-
-    void setMaxFlowDurationMs(long value);
-
     @Description("Amount of time to wait before firing the pane after late data has arrived." +
             "Decrease this value for faster updates, at the cost of more update being fired.")
     @Default.Long(60 * 1000L) // 1 minute

--- a/main/src/test/java/org/apache/beam/sdk/io/kafka/KafkaInputTimestampPolicyFactoryTest.java
+++ b/main/src/test/java/org/apache/beam/sdk/io/kafka/KafkaInputTimestampPolicyFactoryTest.java
@@ -113,7 +113,7 @@ public class KafkaInputTimestampPolicyFactoryTest {
                                                     new RecordHeaders(),
                                                     "key",
                                                     FlowDocument.newBuilder()
-                                                            .setLastSwitched(UInt64Value.of(now.getMillis() + ts))
+                                                            .setDeltaSwitched(UInt64Value.of(now.getMillis() + ts))
                                                             .build()));
                             return result.getMillis() - now.getMillis();
                         })

--- a/main/src/test/java/org/opennms/nephron/FlowAnalyzerTest.java
+++ b/main/src/test/java/org/opennms/nephron/FlowAnalyzerTest.java
@@ -92,11 +92,10 @@ public class FlowAnalyzerTest {
                 .build();
 
         // Build a stream from the given set of flows
-        long timestampOffsetMillis = TimeUnit.MINUTES.toMillis(1);
         TestStream.Builder<FlowDocument> flowStreamBuilder = TestStream.create(new FlowDocumentProtobufCoder());
         for (FlowDocument flow : flowGenerator.streamFlows()) {
             flowStreamBuilder = flowStreamBuilder.addElements(TimestampedValue.of(flow,
-                    org.joda.time.Instant.ofEpochMilli(flow.getLastSwitched().getValue() + timestampOffsetMillis)));
+                    org.joda.time.Instant.ofEpochMilli(flow.getDeltaSwitched().getValue())));
         }
         TestStream<FlowDocument> flowStream = flowStreamBuilder.advanceWatermarkToInfinity();
 


### PR DESCRIPTION
When duplicating flows into all windows they fall into the input flow document is replicated for several timestamps starting at deltaSwitched. When `lastSwitched` is used as the event time of the input flow document then this effectively means a time travel back in time.

Stages should not output elements that are earlier than their input and the method that is used to allow some clock skew is deprecated.

Therefore it seems to be preferable to use `deltaSwitched` as event time of the initial flow document. The general beam mechanism for late input is used to handle flows that have a long duration.

