### PR TITLE
revert to Java 8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
         <beam.version>2.24.0</beam.version>
         <elasticsearch.client.version>7.7.1</elasticsearch.client.version>
         <flink.artifact.name>beam-runners-flink-1.10</flink.artifact.name>
-        <java.version>11</java.version>
+        <java.version>1.8</java.version>
         <junit.version>4.13.1</junit.version>
         <kafka.version>2.6.0</kafka.version>
         <log4j.version>2.13.3</log4j.version>


### PR DESCRIPTION
The nephron-main artifact is used in the integration tests of opennms (which is still on Java 8). Therefore it must be compiled for Java 8.