### PR TITLE
NMS-13116: fix rounding errors in flow sampling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,5 @@ bin/
 java/bin/
 *.swp
 *.iml
+.jqwik-database
+

--- a/main/pom.xml
+++ b/main/pom.xml
@@ -171,6 +171,11 @@
             <version>1.0-SNAPSHOT</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>net.jqwik</groupId>
+            <artifactId>jqwik</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <profiles>

--- a/main/src/main/java/org/opennms/nephron/FlowWindows.java
+++ b/main/src/main/java/org/opennms/nephron/FlowWindows.java
@@ -82,9 +82,12 @@ public class FlowWindows extends NonMergingWindowFn<FlowDocument, FlowWindows.Fl
         // The flow ranges from [delta_switched, last_switched)
         final FlowDocument flow = c.element();
 
+        long deltaSwitchedMillis = flow.getDeltaSwitched().getValue();
+        long lastSwitchedMillis = flow.getLastSwitched().getValue();
+
         // Calculate the first and last window since EPOCH (both inclusive) the flow falls into
-        long firstWindow = flow.getDeltaSwitched().getValue() / windowSize;
-        long lastWindow = flow.getLastSwitched().getValue() / windowSize;
+        long firstWindow = deltaSwitchedMillis / windowSize;
+        long lastWindow = lastSwitchedMillis / windowSize;
 
         // Iterate window numbers for flow duration and build windows
         final List<FlowWindow> windows = Lists.newArrayList();

--- a/main/src/test/java/org/opennms/nephron/KeyFlowByTest.java
+++ b/main/src/test/java/org/opennms/nephron/KeyFlowByTest.java
@@ -1,0 +1,110 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2021 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2021 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.nephron;
+
+import java.util.stream.LongStream;
+
+import net.jqwik.api.Arbitraries;
+import net.jqwik.api.Arbitrary;
+import net.jqwik.api.ForAll;
+import net.jqwik.api.Property;
+import net.jqwik.api.Provide;
+
+public class KeyFlowByTest {
+
+    @Property
+    public boolean test(
+            @ForAll("flowData") FlowData fd,
+            @ForAll("windowSize") long windowSize,
+            @ForAll("multiplier") double multiplier
+    ) {
+        // - determine the overlapping window numbers
+        // - calculate the number of bytes that falls into each of these windows
+        // - sum it up
+        long sampled = LongStream
+                .range(fd.deltaSwitched / windowSize, fd.lastSwitched / windowSize + 1)
+                .map(i ->
+                        Groupings.KeyFlowBy.bytesInWindow(
+                                fd.deltaSwitched,
+                                fd.lastSwitched,
+                                fd.bytes * multiplier,
+                                i * windowSize,
+                                (i + 1) * windowSize - 1
+                        )
+                ).sum();
+        // System.out.println("flow: " + fd + "; windowSize: " + windowSize + "; sampled: " + sampled + "; multiplier: " + multiplier);
+        // the sum of sampled values must be equal to the number of bytes in the flow (considering the multiplier)
+        return sampled == (long)(fd.bytes * multiplier);
+    }
+
+    // an arbitrary long in the range [0, 1000]
+    public static Arbitrary<Long> ARB_LONG = Arbitraries.longs().between(0, 1000);
+
+    @Provide
+    public Arbitrary<Double> multiplier() {
+        // generate arbitrary multipliers with a strong bias for 1.0
+        return Arbitraries.oneOf(Arbitraries.just(1.0), Arbitraries.doubles().between(0.1, 100));
+    }
+
+    @Provide
+    public Arbitrary<Long> windowSize() {
+        // window size must not be zero -> increment by one
+        return ARB_LONG.map(l -> l + 1);
+    }
+
+    @Provide
+    public Arbitrary<FlowData> flowData() {
+        return ARB_LONG.flatMap(
+                deltaSwitched -> ARB_LONG.flatMap(
+                        lastSwitchedIncrement -> ARB_LONG.map(
+                                bytes -> new FlowData(deltaSwitched, deltaSwitched + lastSwitchedIncrement, bytes)
+                        )
+                )
+        );
+    }
+
+    public static class FlowData {
+        public final long deltaSwitched, lastSwitched, bytes;
+
+        public FlowData(long deltaSwitched, long lastSwitched, long bytes) {
+            this.deltaSwitched = deltaSwitched;
+            this.lastSwitched = lastSwitched;
+            this.bytes = bytes;
+        }
+
+        @Override
+        public String toString() {
+            return "FlowData{" +
+                   "deltaSwitched=" + deltaSwitched +
+                   ", lastSwitched=" + lastSwitched +
+                   ", bytes=" + bytes +
+                   '}';
+        }
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -44,6 +44,7 @@
         <protobuf.version>3.11.4</protobuf.version>
         <slf4j.version>1.7.28</slf4j.version>
         <testcontainers.version>1.15.0</testcontainers.version>
+        <jqwik.version>1.3.10</jqwik.version>
     </properties>
 
     <modules>
@@ -169,6 +170,12 @@
                 <groupId>org.elasticsearch.client</groupId>
                 <artifactId>elasticsearch-rest-high-level-client</artifactId>
                 <version>${elasticsearch.client.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>net.jqwik</groupId>
+                <artifactId>jqwik</artifactId>
+                <version>${jqwik.version}</version>
                 <scope>test</scope>
             </dependency>
         </dependencies>


### PR DESCRIPTION
This PR fixes rounding errors that might happen when flows are sampled into their windows.

* moves the check for a negative flow duration into the windows assignment function
* changes the sampling logic that calculates the number of bytes that flows contribute to windows
* adds a property based test that checks that the sum of sampled contributions is equal to the number of bytes of a flow
