### PR TITLE
NMS-13131: Use unaligned windows for different exporters

### DIFF
--- a/main/pom.xml
+++ b/main/pom.xml
@@ -176,6 +176,11 @@
             <artifactId>jqwik</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <profiles>

--- a/main/pom.xml
+++ b/main/pom.xml
@@ -85,6 +85,10 @@
             <artifactId>rate-limited-logger</artifactId>
             <version>2.0.1</version>
         </dependency>
+        <dependency>
+            <groupId>it.unimi.dsi</groupId>
+            <artifactId>fastutil</artifactId>
+        </dependency>
 
         <!-- Test dependencies -->
         <dependency>

--- a/main/src/main/java/org/opennms/nephron/UnalignedFixedWindows.java
+++ b/main/src/main/java/org/opennms/nephron/UnalignedFixedWindows.java
@@ -56,11 +56,9 @@ public class UnalignedFixedWindows extends NonMergingWindowFn<FlowDocument, Inte
      *
      * Shifted windows start at: shift + windowNumber(nodeId, windowSize, timestamp) * windowSize,
      */
-    public static long windowStartForTimestamp(
-            int nodeId,
+    public static long windowStartForTimestamp(int nodeId,
             long windowSize,
-            long timestamp
-    ) {
+            long timestamp) {
         long shift = perNodeShift(nodeId, windowSize);
         return timestamp - (timestamp - shift) % windowSize;
     }

--- a/main/src/main/java/org/opennms/nephron/UnalignedFixedWindows.java
+++ b/main/src/main/java/org/opennms/nephron/UnalignedFixedWindows.java
@@ -1,0 +1,139 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2021 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2021 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.nephron;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Objects;
+
+import org.apache.beam.sdk.coders.Coder;
+import org.apache.beam.sdk.transforms.windowing.IntervalWindow;
+import org.apache.beam.sdk.transforms.windowing.NonMergingWindowFn;
+import org.apache.beam.sdk.transforms.windowing.WindowFn;
+import org.apache.beam.sdk.transforms.windowing.WindowMappingFn;
+import org.joda.time.Duration;
+import org.joda.time.Instant;
+import org.opennms.netmgt.flows.persistence.model.FlowDocument;
+
+public class UnalignedFixedWindows extends NonMergingWindowFn<FlowDocument, IntervalWindow> {
+
+    public static UnalignedFixedWindows of(Duration size) {
+        return new UnalignedFixedWindows(size);
+    }
+
+    public static long perNodeShift(int nodeId, long windowSize) {
+        return Math.abs(Integer.hashCode(nodeId)) % windowSize;
+    }
+
+    /**
+     * Returns the start of a shifted window that includes the given timestamp.
+     *
+     * Shifted windows start at: shift + windowNumber(nodeId, windowSize, timestamp) * windowSize,
+     */
+    public static long windowStartForTimestamp(
+            int nodeId,
+            long windowSize,
+            long timestamp
+    ) {
+        long shift = perNodeShift(nodeId, windowSize);
+        return timestamp - (timestamp - shift) % windowSize;
+    }
+
+    /**
+     * Return the number of the shifted window the given timestamp falls into
+     */
+    public static long windowNumber(
+            int nodeId,
+            long windowSize,
+            long timestamp
+    ) {
+        long shift = perNodeShift(nodeId, windowSize);
+        return (timestamp - shift) / windowSize;
+    }
+
+    public static long windowStartForWindowNumber(
+            int nodeId,
+            long windowSize,
+            long windowNumber
+    ) {
+        long shift = perNodeShift(nodeId, windowSize);
+        return shift + windowNumber * windowSize;
+
+    }
+
+    private final long size;
+
+    private UnalignedFixedWindows(
+            Duration size
+    ) {
+        this.size = Objects.requireNonNull(size).getMillis();
+    }
+
+    @Override
+    public Collection<IntervalWindow> assignWindows(final AssignContext c) throws Exception {
+        final FlowDocument flow = c.element();
+        long timestamp = c.timestamp().getMillis();
+        long startMs = windowStartForTimestamp(flow.getExporterNode().getNodeId(), size, timestamp);
+        Instant start = Instant.ofEpochMilli(startMs);
+        IntervalWindow window = new IntervalWindow(start, start.plus(this.size));
+        return Collections.singleton(window);
+    }
+
+    @Override
+    public boolean isCompatible(WindowFn<?, ?> other) {
+        return Objects.equals(this, other);
+    }
+
+    @Override
+    public Coder<IntervalWindow> windowCoder() {
+        return IntervalWindow.getCoder();
+    }
+
+    @Override
+    public WindowMappingFn<IntervalWindow> getDefaultWindowMappingFn() {
+        return null;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        UnalignedFixedWindows that = (UnalignedFixedWindows) o;
+        return size == that.size;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(size);
+    }
+}

--- a/main/src/main/java/org/opennms/nephron/UnalignedFixedWindows.java
+++ b/main/src/main/java/org/opennms/nephron/UnalignedFixedWindows.java
@@ -41,6 +41,8 @@ import org.joda.time.Duration;
 import org.joda.time.Instant;
 import org.opennms.netmgt.flows.persistence.model.FlowDocument;
 
+import it.unimi.dsi.fastutil.HashCommon;
+
 public class UnalignedFixedWindows extends NonMergingWindowFn<FlowDocument, IntervalWindow> {
 
     public static UnalignedFixedWindows of(Duration size) {
@@ -48,7 +50,7 @@ public class UnalignedFixedWindows extends NonMergingWindowFn<FlowDocument, Inte
     }
 
     public static long perNodeShift(int nodeId, long windowSize) {
-        return Math.abs(Integer.hashCode(nodeId)) % windowSize;
+        return Math.abs(HashCommon.mix(nodeId)) % windowSize;
     }
 
     /**
@@ -87,9 +89,7 @@ public class UnalignedFixedWindows extends NonMergingWindowFn<FlowDocument, Inte
 
     private final long size;
 
-    private UnalignedFixedWindows(
-            Duration size
-    ) {
+    private UnalignedFixedWindows(Duration size) {
         this.size = Objects.requireNonNull(size).getMillis();
     }
 

--- a/main/src/test/java/org/opennms/nephron/UnalignedFixedWindowsTest.java
+++ b/main/src/test/java/org/opennms/nephron/UnalignedFixedWindowsTest.java
@@ -1,0 +1,80 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2021 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2021 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.nephron;
+
+import net.jqwik.api.Arbitraries;
+import net.jqwik.api.Arbitrary;
+import net.jqwik.api.ForAll;
+import net.jqwik.api.Property;
+import net.jqwik.api.Provide;
+
+public class UnalignedFixedWindowsTest {
+
+    @Provide
+    public Arbitrary<Integer> nodeId() {
+        return Arbitraries.integers().between(0, 10);
+    }
+
+    @Provide
+    public Arbitrary<Long> windowSize() {
+        return Arbitraries.longs().between(1, 10);
+    }
+
+    @Provide
+    public Arbitrary<Long> timestamp() {
+        return Arbitraries.longs().between(100, 1000);
+    }
+
+    @Property
+    public boolean canCalculateStartOfShiftedWindowForFlowTimestamp(
+            @ForAll("nodeId") int nodeId,
+            @ForAll("windowSize") long windowSize,
+            @ForAll("timestamp") long timestamp
+    ) {
+        long start = UnalignedFixedWindows.windowStartForTimestamp(nodeId, windowSize, timestamp);
+        long shift = UnalignedFixedWindows.perNodeShift(nodeId, windowSize);
+        // check that
+        // - the start of the unshifted window (i.e. start - shift) is a multiple of the window size
+        // - the timestamp is included in the shifted window
+        return (start - shift) % windowSize == 0 && start <= timestamp && start + windowSize > timestamp;
+    }
+
+    @Property
+    public boolean startAndWindowNumberCalculationsAreConsistent(
+            @ForAll("nodeId") int nodeId,
+            @ForAll("windowSize") long windowSize,
+            @ForAll("timestamp") long timestamp
+    ) {
+        long startForTimestamp = UnalignedFixedWindows.windowStartForTimestamp(nodeId, windowSize, timestamp);
+        long windowNumber = UnalignedFixedWindows.windowNumber(nodeId, windowSize, timestamp);
+        long startForWindowNumber = UnalignedFixedWindows.windowStartForWindowNumber(nodeId, windowSize, windowNumber);
+        return startForTimestamp == startForWindowNumber;
+    }
+
+}

--- a/main/src/test/java/org/opennms/nephron/flowgen/FlowGenerator.java
+++ b/main/src/test/java/org/opennms/nephron/flowgen/FlowGenerator.java
@@ -229,13 +229,13 @@ public class FlowGenerator {
                     .withApplication(applicationForConversation);
             if (flowIndex % 2 == 0) {
                 flowBuilder.withDirection(Direction.INGRESS)
-                        .withFlow(startOfFlow, startOfFlow.plusMillis(flowDurationMillis),
+                        .withFlow(startOfFlow, startOfFlow.plusMillis(flowDurationMillis).minusMillis(1),
                                 sourceIp, srcPort,
                                 dstIp, dstPort,
                                 ingressBytesPerFlow);
             } else {
                 flowBuilder.withDirection(Direction.EGRESS)
-                        .withFlow(startOfFlow, startOfFlow.plusMillis(flowDurationMillis),
+                        .withFlow(startOfFlow, startOfFlow.plusMillis(flowDurationMillis).minusMillis(1),
                                 dstIp, dstPort,
                                 sourceIp, srcPort,
                                 egressBytesPerFlow);

--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
         <elasticsearch.client.version>7.7.1</elasticsearch.client.version>
         <flink.artifact.name>beam-runners-flink-1.10</flink.artifact.name>
         <java.version>1.8</java.version>
-        <junit.version>4.13.1</junit.version>
+        <junit.version>4.13</junit.version>
         <kafka.version>2.6.0</kafka.version>
         <log4j.version>2.13.3</log4j.version>
         <opennms.version>26.1.0-SNAPSHOT</opennms.version>
@@ -172,10 +172,21 @@
                 <version>${elasticsearch.client.version}</version>
                 <scope>test</scope>
             </dependency>
+            <!--
+                if the jqwik dependency is added then the junit-vintage-engine must be added too
+                -> the auto-detection mechanism of the surefire plugin does no more add the
+                   junit-vintage-engine because jqwik already adds the jqwik-engine
+            -->
             <dependency>
                 <groupId>net.jqwik</groupId>
                 <artifactId>jqwik</artifactId>
                 <version>${jqwik.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.junit.vintage</groupId>
+                <artifactId>junit-vintage-engine</artifactId>
+                <version>5.6.2</version>
                 <scope>test</scope>
             </dependency>
         </dependencies>
@@ -221,8 +232,8 @@
                     <version>3.0.0-M4</version>
                 </plugin>
                 <plugin>
-                    <groupId>org.apache.maven.surefire</groupId>
-                    <artifactId>surefire</artifactId>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-surefire-plugin</artifactId>
                     <version>2.22.2</version>
                 </plugin>
             </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -116,6 +116,11 @@
                 <artifactId>rate-limited-logger</artifactId>
                 <version>2.0.1</version>
             </dependency>
+            <dependency>
+                <groupId>it.unimi.dsi</groupId>
+                <artifactId>fastutil</artifactId>
+                <version>8.5.2</version>
+            </dependency>
 
             <!-- Test dependencies -->
             <dependency>


### PR DESCRIPTION
https://issues.opennms.org/browse/NMS-13131

In addition to using unaligned windows, the execution of unit tests by the surefire plugin is reactivated. (Adding jqwik test had the surprising side effect that standard junit tests were no more detected.)