### PR TITLE
fix lastSwitched of generated flows (it is considered inclusive)

### DIFF
--- a/generator/src/main/java/org/opennms/nephron/generator/Handler.java
+++ b/generator/src/main/java/org/opennms/nephron/generator/Handler.java
@@ -135,7 +135,7 @@ public class Handler implements BiConsumer<Exporter, FlowReport>, Closeable {
         flowBuilder.setDstHostname(dstAddr.hostname);
         flowBuilder.setFirstSwitched(UInt64Value.of(report.getStart().plus(exporter.getClockOffset()).toEpochMilli()));
         flowBuilder.setDeltaSwitched(UInt64Value.of(report.getStart().plus(exporter.getClockOffset()).toEpochMilli()));
-        flowBuilder.setLastSwitched(UInt64Value.of(report.getEnd().plus(exporter.getClockOffset()).toEpochMilli()));
+        flowBuilder.setLastSwitched(UInt64Value.of(report.getEnd().minusMillis(1).plus(exporter.getClockOffset()).toEpochMilli()));
         flowBuilder.setNumBytes(UInt64Value.of(report.getBytes()));
         flowBuilder.setConvoKey(convoKey);
         flowBuilder.setInputSnmpIfindex(UInt32Value.of(exporter.getInputSnmp()));

--- a/main/src/test/java/org/opennms/nephron/RandomFlowIT.java
+++ b/main/src/test/java/org/opennms/nephron/RandomFlowIT.java
@@ -53,7 +53,6 @@ import java.util.TreeMap;
 import java.util.TreeSet;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
-import java.util.function.BiConsumer;
 import java.util.stream.Collectors;
 
 import org.apache.beam.runners.flink.FlinkPipelineOptions;
@@ -84,7 +83,6 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.opennms.nephron.catheter.Exporter;
-import org.opennms.nephron.catheter.FlowReport;
 import org.opennms.nephron.catheter.Simulation;
 import org.opennms.nephron.elastic.FlowSummary;
 import org.opennms.nephron.generator.Handler;


### PR DESCRIPTION
Nephron assumes `lastSwitched` to be inclusive. Generated flows must match that assumption to get expected byte rates.