### PR TITLE
NMS-13262: Update Java and Flink

### DIFF
--- a/main/pom.xml
+++ b/main/pom.xml
@@ -136,7 +136,7 @@
         <dependency>
             <groupId>org.apache.flink</groupId>
             <artifactId>flink-test-utils_2.12</artifactId>
-            <version>1.10.2</version>
+            <version>1.12.3</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/main/src/main/java/org/opennms/nephron/UnalignedFixedWindows.java
+++ b/main/src/main/java/org/opennms/nephron/UnalignedFixedWindows.java
@@ -62,6 +62,10 @@ public class UnalignedFixedWindows extends NonMergingWindowFn<FlowDocument, Inte
             long windowSize,
             long timestamp) {
         long shift = perNodeShift(nodeId, windowSize);
+        if (timestamp < shift) {
+            throw new RuntimeException("timestamp too small; it lies before the first window - timestamp: " +
+                                       timestamp + "; windowShift: " + shift);
+        }
         return timestamp - (timestamp - shift) % windowSize;
     }
 

--- a/main/src/main/java/org/opennms/nephron/UnalignedFixedWindows.java
+++ b/main/src/main/java/org/opennms/nephron/UnalignedFixedWindows.java
@@ -62,10 +62,6 @@ public class UnalignedFixedWindows extends NonMergingWindowFn<FlowDocument, Inte
             long windowSize,
             long timestamp) {
         long shift = perNodeShift(nodeId, windowSize);
-        if (timestamp < shift) {
-            throw new RuntimeException("timestamp too small; it lies before the first window - timestamp: " +
-                                       timestamp + "; windowShift: " + shift);
-        }
         return timestamp - (timestamp - shift) % windowSize;
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -33,10 +33,10 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <beam.version>2.24.0</beam.version>
+        <beam.version>2.29.0</beam.version>
         <elasticsearch.client.version>7.7.1</elasticsearch.client.version>
-        <flink.artifact.name>beam-runners-flink-1.10</flink.artifact.name>
-        <java.version>1.8</java.version>
+        <flink.artifact.name>beam-runners-flink-1.12</flink.artifact.name>
+        <java.version>11</java.version>
         <junit.version>4.13</junit.version>
         <kafka.version>2.6.0</kafka.version>
         <log4j.version>2.13.3</log4j.version>


### PR DESCRIPTION
Issue: https://issues.opennms.org/browse/NMS-13262

* Updates Java 8 -> 11
* Updates Flink 1.10 -> 1.12
* Adds a check that timestamps are not too small for the unaligned windows logic

(The timestamp check is only relevant for testing when very small timestamps may be used.)