### PR TITLE
no-jira: rate limiter now takes part in checkpoint

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
         <protobuf.version>3.11.4</protobuf.version>
         <slf4j.version>1.7.30</slf4j.version>
         <testcontainers.version>1.15.3</testcontainers.version>
-        <jqwik.version>1.3.10</jqwik.version>
+        <jqwik.version>1.5.1</jqwik.version>
     </properties>
 
     <modules>

--- a/testing/pom.xml
+++ b/testing/pom.xml
@@ -71,10 +71,6 @@
             <artifactId>jackson-datatype-joda</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>jcl-over-slf4j</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-slf4j-impl</artifactId>
             <version>${log4j.version}</version>
@@ -89,15 +85,14 @@
             <artifactId>${flink.artifact.name}</artifactId>
             <version>${beam.version}</version>
         </dependency>
-
-
-        <!-- Test dependencies -->
         <dependency>
             <groupId>org.apache.beam</groupId>
             <artifactId>beam-runners-direct-java</artifactId>
             <version>${beam.version}</version>
-            <scope>test</scope>
+            <scope>compile</scope>
         </dependency>
+
+        <!-- Test dependencies -->
         <dependency>
             <groupId>org.awaitility</groupId>
             <artifactId>awaitility</artifactId>
@@ -148,24 +143,6 @@
 <!--        </dependency>-->
 
     </dependencies>
-
-    <profiles>
-        <profile>
-            <id>direct-runner</id>
-            <activation>
-                <activeByDefault>true</activeByDefault>
-            </activation>
-            <!-- Makes the DirectRunner available when running a pipeline. -->
-            <dependencies>
-                <dependency>
-                    <groupId>org.apache.beam</groupId>
-                    <artifactId>beam-runners-direct-java</artifactId>
-                    <version>${beam.version}</version>
-                    <scope>runtime</scope>
-                </dependency>
-            </dependencies>
-        </profile>
-    </profiles>
 
     <repositories>
         <repository>

--- a/testing/src/main/java/org/opennms/nephron/testing/benchmark/Benchmark.java
+++ b/testing/src/main/java/org/opennms/nephron/testing/benchmark/Benchmark.java
@@ -32,6 +32,8 @@ import static org.opennms.nephron.Pipeline.registerCoders;
 
 import java.util.Objects;
 
+import org.apache.beam.runners.direct.DirectOptions;
+import org.apache.beam.runners.flink.FlinkPipelineOptions;
 import org.apache.beam.runners.flink.FlinkRunner;
 import org.apache.beam.sdk.PipelineResult;
 import org.apache.beam.sdk.metrics.Counter;
@@ -71,6 +73,10 @@ public class Benchmark {
     // --flowsPerSecond=10000
     public static void main(String[] args) throws Exception {
         args = ensureArg("--blockOnRun=false", args);
+        args = ensureArg("--runner=FlinkRunner", args);
+        PipelineOptionsFactory.register(DirectOptions.class);
+        PipelineOptionsFactory.register(FlinkPipelineOptions.class);
+        PipelineOptionsFactory.register(BenchmarkOptions.class);
         PipelineOptionsFactory.register(NephronOptions.class);
         PipelineOptionsFactory.register(FlowGenOptions.class);
         var options = PipelineOptionsFactory.fromArgs(args).withValidation().as(BenchmarkOptions.class);

--- a/testing/src/main/java/org/opennms/nephron/testing/flowgen/FlowGenOptions.java
+++ b/testing/src/main/java/org/opennms/nephron/testing/flowgen/FlowGenOptions.java
@@ -31,8 +31,38 @@ package org.opennms.nephron.testing.flowgen;
 import org.apache.beam.sdk.options.Default;
 import org.apache.beam.sdk.options.Description;
 import org.opennms.nephron.NephronOptions;
-import org.opennms.nephron.testing.benchmark.InputSetup;
 
+/**
+ * Defines the distribution of generated flows.
+ *
+ * Parameters can be grouped into the following areas:
+ *
+ * <dl>
+ *     <dt>Randomness</dt>
+ *     <dd>
+ *         <ul>
+ *             <li>seed</li>
+ *             <li>playbackMode</li>
+ *             <li>startMs (only use in playback mode)</li>
+ *         </ul>
+ *     </dd>
+ *     <dt>Flow instances</dt>
+ *     <dd>
+ *         <ul>
+ *             <li>fixedWindowsSizeMs (inherited from NephronOptions)</li>
+ *             <li>numWindows</li>
+ *             <li>flowsPerWindow || flowsPerSecond</li>
+ *         </ul>
+ *     </dd>
+ *     <dt>Flow attributes</dt>
+ *     <dd>
+ *         <ul>
+ *             <li>numExporters, numInterfaces, numApplications, numHosts, numDscps, numEcns</li>
+ *             <li>lastSwitchedSigma, flowDurationLambda</li>
+ *         </ul>
+ *     </dd>
+ * </dl>
+ */
 public interface FlowGenOptions extends NephronOptions {
 
     @Description("Seed for generating synthetic flows.")

--- a/testing/src/main/java/org/opennms/nephron/testing/flowgen/FlowReader.java
+++ b/testing/src/main/java/org/opennms/nephron/testing/flowgen/FlowReader.java
@@ -121,7 +121,7 @@ public class FlowReader extends UnboundedSource.UnboundedReader<FlowDocument> {
 
     @Override
     public UnboundedSource.CheckpointMark getCheckpointMark() {
-        return new CheckpointMark(timestampPolicy.getCheckpointInstant(), index, random);
+        return new CheckpointMark(timestampPolicy.getCheckpointInstant(), index, random, limiter.state());
     }
 
     @Override
@@ -163,6 +163,7 @@ public class FlowReader extends UnboundedSource.UnboundedReader<FlowDocument> {
                 INSTANT_CODER.encode(value.previous, outStream);
                 LONG_CODER.encode(value.index, outStream);
                 RANDOM_CODER.encode(value.random, outStream);
+                LONG_CODER.encode(value.limiterState, outStream);
             }
 
             @Override
@@ -170,7 +171,8 @@ public class FlowReader extends UnboundedSource.UnboundedReader<FlowDocument> {
                 return new CheckpointMark(
                         INSTANT_CODER.decode(inStream),
                         LONG_CODER.decode(inStream),
-                        RANDOM_CODER.decode(inStream)
+                        RANDOM_CODER.decode(inStream),
+                        LONG_CODER.decode(inStream)
                 );
             }
         };
@@ -179,11 +181,13 @@ public class FlowReader extends UnboundedSource.UnboundedReader<FlowDocument> {
         public final Instant previous;
         public final long index;
         public final Random random;
+        public final long limiterState;
 
-        public CheckpointMark(Instant previous, long index, Random random) {
+        public CheckpointMark(Instant previous, long index, Random random, long limiterState) {
             this.previous = previous;
             this.index = index;
             this.random = random;
+            this.limiterState = limiterState;
         }
 
         @Override

--- a/testing/src/test/java/org/opennms/nephron/testing/flowgen/LimiterTest.java
+++ b/testing/src/test/java/org/opennms/nephron/testing/flowgen/LimiterTest.java
@@ -1,0 +1,183 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2021 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2021 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.nephron.testing.flowgen;
+
+import java.util.List;
+
+import org.apache.flink.types.Either;
+
+import net.jqwik.api.Arbitraries;
+import net.jqwik.api.Arbitrary;
+import net.jqwik.api.ForAll;
+import net.jqwik.api.Property;
+import net.jqwik.api.Provide;
+import net.jqwik.api.Tuple;
+
+public class LimiterTest {
+
+    /**
+     * Holds the state that used to verify that taking checkpoints does not change the rate-limiting behavior of
+     * a limiter.
+     */
+    private static class State {
+        // the wall clock that is used by both limiters
+        private long currentTimeMillis;
+        private long flowsPerSecond;
+        // a reference limiter that does not take part in checkpoints
+        private Limiter referenceLimiter;
+        // either a limiter or its state that is saved in checkpoints and used to restore the limiter
+        private Either<Limiter, Long> limiterOrState;
+
+        public State(long currentTimeMillis, long flowsPerSecond) {
+            this.currentTimeMillis = currentTimeMillis;
+            this.flowsPerSecond = flowsPerSecond;
+            referenceLimiter = Limiter.of(flowsPerSecond, () -> this.currentTimeMillis);
+            limiterOrState = new Either.Left(Limiter.of(flowsPerSecond, () -> this.currentTimeMillis));
+        }
+
+        @Override
+        public String toString() {
+            return "State.of(" + currentTimeMillis +"," + flowsPerSecond + ')';
+        }
+    }
+
+    /**
+     * Represents actions that are executed in arbitrary sequence on the test state.
+     */
+    interface Action {
+        /**
+         * Applies this action on the state.
+         *
+         * @return Returns <code>true</code> iff executing this action did not show a mismatch between
+         * the reference limiter contained in the state and the limiter that takes part in checkpoints.
+         */
+        boolean exec(State state);
+    }
+
+    public static class TickAction implements Action {
+        public static TickAction of(long ms) {
+            return new TickAction(ms);
+        }
+        public final long ms;
+        public TickAction(long ms) {
+            this.ms = ms;
+        }
+        @Override
+        public boolean exec(State state) {
+            state.currentTimeMillis += ms;
+            return true;
+        }
+
+        @Override
+        public String toString() {
+            return "TickAction.of(" + ms + ')';
+        }
+    }
+
+    public static class CheckAction implements Action {
+        public static CheckAction of(int flowsPerSecond, int incr) {
+            return new CheckAction(flowsPerSecond, incr);
+        }
+        public final int flowsPerSecond, incr;
+        public CheckAction(int flowsPerSecond, int incr) {
+            this.flowsPerSecond = flowsPerSecond;
+            this.incr = incr;
+        }
+        @Override
+        public boolean exec(State state) {
+            if (state.limiterOrState.isRight()) {
+                // restore limiter from its limiter state
+                state.limiterOrState = new Either.Left(Limiter.restore(flowsPerSecond, state.limiterOrState.right(), () -> state.currentTimeMillis));
+            }
+            var limiter = state.limiterOrState.left();
+            return limiter.check(incr) == state.referenceLimiter.check(incr);
+        }
+
+        @Override
+        public String toString() {
+            return "CheckAction.of(" + flowsPerSecond +"," + incr + ')';
+        }
+    }
+
+    public static class CheckpointAction implements Action {
+        public static CheckpointAction of() {
+            return new CheckpointAction();
+        }
+        @Override
+        public boolean exec(State state) {
+            if (state.limiterOrState.isLeft()) {
+                state.limiterOrState = new Either.Right(state.limiterOrState.left().state());
+            }
+            return true;
+        }
+
+        @Override
+        public String toString() {
+            return "CheckpointAction.of()";
+        }
+    }
+
+    private static Arbitrary<Action> action(int flowsPerSecond) {
+        var tick = Arbitraries.longs().between(1, 10).map(TickAction::new);
+        var check = Arbitraries.integers().between(1, 3).map(incr -> new CheckAction(flowsPerSecond, incr));
+        var checkpoint = Arbitraries.just(new CheckpointAction());
+        return Arbitraries.frequencyOf(
+                Tuple.of(1, tick),
+                Tuple.of(1, check),
+                Tuple.of(1, checkpoint)
+        );
+    }
+
+    /**
+     * Provides an initial state and a list of actions that are applied to the state.
+     */
+    @Provide
+    public Arbitrary<Tuple.Tuple2<State, List<Action>>> stateAndActions() {
+        return Arbitraries.integers()
+                .between(50, 5000)
+                .flatMap(flowsPerSecond -> action(flowsPerSecond).list().map(list -> Tuple.of(new State(1_500_000_000_000l, flowsPerSecond), list)));
+    }
+
+    /**
+     * Checks that the limiting behavior of a reference limiter that does not take part in checkpoints and the limiter
+     * that does match when starting from the given state and applying the given list of actions.
+     */
+    @Property
+    public boolean checkpointsDoNotInfluenceTheRate(
+            @ForAll("stateAndActions") Tuple.Tuple2<State, List<Action>> stateAndActions
+    ) {
+        var state = stateAndActions.get1();
+        for (var a: stateAndActions.get2()) {
+            var b = a.exec(state);
+            if (!b) return b;
+        }
+        return true;
+    }
+
+}


### PR DESCRIPTION
When running benchmarks with the direct runner checkpoints of the input are taken at regular intervals. The rate limiter state must also be part of that checkpoint in order to guarantee its rate-limiting behavior even in case of checkpoints.