### PR TITLE
NMS-13467: support additonal flow summary accumulation

### DIFF
--- a/cortex/pom.xml
+++ b/cortex/pom.xml
@@ -130,6 +130,10 @@
             <groupId>com.squareup.okhttp3</groupId>
             <artifactId>logging-interceptor</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+        </dependency>
 
 
         <!-- Test dependencies -->

--- a/cortex/src/main/java/org/opennms/nephron/cortex/CortexIo.java
+++ b/cortex/src/main/java/org/opennms/nephron/cortex/CortexIo.java
@@ -222,7 +222,7 @@ public class CortexIo {
         }
 
         public Write<K, V> withOrgId(String value) {
-            this.orgId = orgId;
+            this.orgId = value;
             return this;
         }
 

--- a/cortex/src/main/java/org/opennms/nephron/cortex/CortexIo.java
+++ b/cortex/src/main/java/org/opennms/nephron/cortex/CortexIo.java
@@ -108,6 +108,10 @@ import prometheus.PrometheusTypes;
  * additionally uses Beam's timer mechanism to hold back values for accumulation and flushes values after a configured
  * output delay.
  * <p>
+ * Note: The {@code PaneAccumulator} class can be used to achieve the same accumulation effect that the accumulating
+ * Cortex sink has. It makes sense to use the {@code PaneAccumulator} if several sinks can benefit
+ * from accumulated outputs. In case of a single sink the accumulating Cortex sink is preferable.
+ * <p>
  * Sinks are configured by the {@link Write} class and are implemented by subclasses of the {@link WriteFn} class.
  * Sinks provide the following counter metrics in the "cortex" namespace:
  * <dl>

--- a/cortex/src/test/resources/cortex.yaml
+++ b/cortex/src/test/resources/cortex.yaml
@@ -26,6 +26,8 @@ distributor:
 
 limits:
   ingestion_rate: 0
+  max_series_per_metric: 1000000
+  max_series_per_user: 0
 
 ingester_client:
   grpc_client_config:

--- a/main/src/main/java/org/opennms/nephron/NephronOptions.java
+++ b/main/src/main/java/org/opennms/nephron/NephronOptions.java
@@ -145,6 +145,11 @@ public interface NephronOptions extends PipelineOptions, CortexOptions {
 
     void setAllowedLatenessMs(long value);
 
+    @Description("Experimental: Accumulation period for flow summaries. Summary accumulation is switched off if set to zero.")
+    @Default.Long(0)
+    long getSummaryAccumulationDelayMs();
+    void setSummaryAccumulationDelayMs(long value);
+
     @Description("Elasticsearch Connection Timeout in milliseconds")
     @Default.Integer(30 * 1000) // 30 seconds
     int getElasticConnectTimeout();
@@ -173,4 +178,5 @@ public interface NephronOptions extends PipelineOptions, CortexOptions {
     String getKafkaClientProperties();
 
     void setKafkaClientProperties(String kafkaClientProperties);
+
 }

--- a/main/src/main/java/org/opennms/nephron/Pipeline.java
+++ b/main/src/main/java/org/opennms/nephron/Pipeline.java
@@ -362,18 +362,19 @@ public class Pipeline {
             TimeSeriesBuilder builder
     ) {
         final var agg = fsd.aggregate;
-        LOG.trace("cortex output - eventTimestamp: {}; keyType: {}; key: {}; index: {}; in: {}; out: {}; total: {}",
-                eventTimestamp, fsd.key.type, fsd.key, index, agg.getBytesIn(), agg.getBytesOut(), agg.getBytesIn() + agg.getBytesOut());
-        String pane = "pane-" + index;
-        doCortexOutput(fsd, eventTimestamp, pane, "in", agg.getBytesIn(), builder);
+        if (LOG.isTraceEnabled()) {
+            LOG.trace("cortex output - eventTimestamp: {}; keyType: {}; key: {}; index: {}; in: {}; out: {}; total: {}",
+                    eventTimestamp, fsd.key.type, fsd.key, index, agg.getBytesIn(), agg.getBytesOut(), agg.getBytesIn() + agg.getBytesOut());
+        }
+        doCortexOutput(fsd, eventTimestamp, index, "in", agg.getBytesIn(), builder);
         builder.nextSeries();
-        doCortexOutput(fsd, eventTimestamp, pane, "out", agg.getBytesOut(), builder);
+        doCortexOutput(fsd, eventTimestamp, index, "out", agg.getBytesOut(), builder);
     }
 
     private static void doCortexOutput(
             FlowSummaryData fsd,
             Instant eventTimestamp,
-            String paneId,
+            int paneId,
             String direction,
             long bytes,
             TimeSeriesBuilder builder

--- a/main/src/main/java/org/opennms/nephron/util/PaneAccumulator.java
+++ b/main/src/main/java/org/opennms/nephron/util/PaneAccumulator.java
@@ -1,0 +1,150 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2021 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2021 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.nephron.util;
+
+import org.apache.beam.sdk.coders.Coder;
+import org.apache.beam.sdk.coders.KvCoder;
+import org.apache.beam.sdk.state.StateSpec;
+import org.apache.beam.sdk.state.StateSpecs;
+import org.apache.beam.sdk.state.TimeDomain;
+import org.apache.beam.sdk.state.Timer;
+import org.apache.beam.sdk.state.TimerSpec;
+import org.apache.beam.sdk.state.TimerSpecs;
+import org.apache.beam.sdk.state.ValueState;
+import org.apache.beam.sdk.transforms.DoFn;
+import org.apache.beam.sdk.transforms.PTransform;
+import org.apache.beam.sdk.transforms.ParDo;
+import org.apache.beam.sdk.transforms.SerializableBiFunction;
+import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
+import org.apache.beam.sdk.values.KV;
+import org.apache.beam.sdk.values.PCollection;
+import org.joda.time.Duration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * A stateful transform that accumulates values of different panes and flushes accumulated values after a given output
+ * delay.
+ */
+public class PaneAccumulator<K, V> extends PTransform<PCollection<KV<K, V>>, PCollection<KV<K, V>>> {
+
+    private static final Logger LOG = LoggerFactory.getLogger(PaneAccumulator.class);
+
+    private final SerializableBiFunction<V, V, V> combiner;
+    private final Duration accumulationDelay;
+    private final Coder<K> keyCoder;
+    private final Coder<V> valueCoder;
+
+    public PaneAccumulator(
+            SerializableBiFunction<V, V, V> combiner,
+            Duration accumulationDelay,
+            Coder<K> keyCoder,
+            Coder<V> valueCoder
+    ) {
+        super("paneAcc");
+        this.combiner = combiner;
+        this.accumulationDelay = accumulationDelay;
+        this.keyCoder = keyCoder;
+        this.valueCoder = valueCoder;
+    }
+
+    @Override
+    public PCollection<KV<K, V>> expand(PCollection<KV<K, V>> input) {
+        return input.apply(ParDo.of(new PaneCombinerFn())).setCoder(KvCoder.of(keyCoder, valueCoder));
+    }
+
+    private class PaneCombinerFn extends DoFn<KV<K, V>, KV<K, V>> {
+
+        private static final String VALUE_STATE_NAME = "value";
+        private static final String OUTPUT_TIMER_NAME = "output";
+
+        @StateId(VALUE_STATE_NAME)
+        private final StateSpec<ValueState<V>> valueStateSpec = StateSpecs.value(valueCoder);
+
+        @TimerId(OUTPUT_TIMER_NAME)
+        private final TimerSpec outputTimerSpec = TimerSpecs.timer(TimeDomain.PROCESSING_TIME);
+
+        @ProcessElement
+        public void process(
+                ProcessContext ctx,
+                BoundedWindow window,
+                @AlwaysFetched @StateId(VALUE_STATE_NAME) ValueState<V> valueState,
+                @TimerId(OUTPUT_TIMER_NAME) Timer timer
+        ) {
+            var oldValue = valueState.read();
+            V newValue;
+            if (oldValue == null) {
+                if (LOG.isTraceEnabled()) {
+                    LOG.trace("create state - key: {}; ctx.timestamp: {}; window.maxTimestamp: {}", ctx.element().getKey(), ctx.timestamp(), window.maxTimestamp());
+                }
+                newValue = ctx.element().getValue();
+                timer.withOutputTimestamp(window.maxTimestamp()).offset(accumulationDelay).setRelative();
+            } else {
+                newValue = combiner.apply(oldValue, ctx.element().getValue());
+            }
+            if (LOG.isTraceEnabled()) {
+                LOG.trace("write state - key: {}; ctx.timestamp: {}; window.maxTimestamp: {}; newValue: {}", ctx.element().getKey(), ctx.timestamp(), window.maxTimestamp(), newValue);
+            }
+            valueState.write(newValue);
+        }
+
+        @OnTimer(OUTPUT_TIMER_NAME)
+        public void onOutput(
+                OnTimerContext ctx,
+                BoundedWindow window,
+                @Key K key,
+                @AlwaysFetched @StateId(VALUE_STATE_NAME) ValueState<V> valueState
+                ) {
+            var value = valueState.read();
+            if (LOG.isTraceEnabled()) {
+                LOG.trace("output state - key: {}; ctx.timestamp: {}, window.maxTimestamp: {}", key, ctx.timestamp(), window.maxTimestamp());
+            }
+            ctx.outputWithTimestamp(KV.of(key, value), window.maxTimestamp());
+            valueState.clear();
+        }
+
+        @OnWindowExpiration
+        public void onExpiration(
+                OutputReceiver<KV<K, V>> ctx,
+                BoundedWindow window,
+                @Key K key,
+                @AlwaysFetched @StateId(VALUE_STATE_NAME) ValueState<V> valueState
+        ) {
+            var value = valueState.read();
+            if (value != null) {
+                if (LOG.isTraceEnabled()) {
+                    LOG.trace("output expired state - key: {}; window.maxTimestamp: {}", key, window.maxTimestamp());
+                }
+                ctx.outputWithTimestamp(KV.of(key, value), window.maxTimestamp());
+            }
+        }
+
+    }
+
+}

--- a/testing/args/flow-gen.arg
+++ b/testing/args/flow-gen.arg
@@ -1,1 +1,1 @@
---lastSwitchedSigmaMs=5000 --flowDurationLambda=0.5 --numExporters=2 --numInterfaces=2 --numProtocols=1 --numApplications=2 --numHosts=2 --numEcns=4 --numDscps=15
+--maxSplits=4 --lastSwitchedSigmaMs=5000 --flowDurationLambda=0.5 --numExporters=2 --numInterfaces=2 --numProtocols=1 --numApplications=2 --numHosts=2 --numEcns=4 --numDscps=15

--- a/testing/args/time.arg
+++ b/testing/args/time.arg
@@ -1,1 +1,1 @@
---numWindows=20 --fixedWindowSizeMs=10000 --defaultMaxInputDelayMs=60000 --earlyProcessingDelayMs=5000 --lateProcessingDelayMs=5000
+--numWindows=20 --fixedWindowSizeMs=10000 --earlyProcessingDelayMs=10000 --lateProcessingDelayMs=10000 --defaultMaxInputDelayMs=60000 --allowedLatenessMs=120000 --sleepBetweenRunsMs=60000

--- a/testing/src/main/java/org/opennms/nephron/testing/benchmark/Benchmark.java
+++ b/testing/src/main/java/org/opennms/nephron/testing/benchmark/Benchmark.java
@@ -239,8 +239,8 @@ public class Benchmark {
         // add an additional label that differentiates benchmark runs
         // -> ensures that samples of different runs do not conflict
         //    (Cortex's sample time ordering constraint could be violated because the EventTimestampIndexer logic is started anew for each run)
-        // -> use the current minute as a distinguishing value
-        attachWriteToCortex(options, flowSummaries, cw -> cw.withFixedLabel("bmr", String.valueOf(Instant.now().get(DateTimeFieldType.minuteOfHour()))));
+        // -> use the current time as a distinguishing value
+        attachWriteToCortex(options, flowSummaries, cw -> cw.withFixedLabel("bmr", Instant.now().toString()));
 
         flowSummaries.apply(devNull("summaries"));
 

--- a/testing/src/main/java/org/opennms/nephron/testing/benchmark/Benchmark.java
+++ b/testing/src/main/java/org/opennms/nephron/testing/benchmark/Benchmark.java
@@ -28,6 +28,7 @@
 
 package org.opennms.nephron.testing.benchmark;
 
+import static org.opennms.nephron.Pipeline.accumulateSummariesIfNecessary;
 import static org.opennms.nephron.Pipeline.attachWriteToCortex;
 import static org.opennms.nephron.Pipeline.attachWriteToElastic;
 import static org.opennms.nephron.Pipeline.registerCoders;
@@ -223,6 +224,8 @@ public class Benchmark {
                 .apply(inputSetup.source())
                 .apply(inTestingProbe.getTransform())
                 .apply(new Pipeline.CalculateFlowStatistics(options));
+
+        flowSummaries = accumulateSummariesIfNecessary(options, flowSummaries);
 
         flowSummaries = flowSummaries.apply(outTestingProbe.getTransform());
 

--- a/testing/src/main/java/org/opennms/nephron/testing/benchmark/Benchmark.java
+++ b/testing/src/main/java/org/opennms/nephron/testing/benchmark/Benchmark.java
@@ -119,44 +119,46 @@ public class Benchmark {
 
         var executor = Executors.newSingleThreadExecutor();
 
-        for (var paramList: paramLists) {
-            executeCommand(cmdLineArgs.before);
-            var as = paramList.toArray(new String[0]);
-            as = ensureArg("--blockOnRun=false", as);
-            // the benchmark may write to ES; disabled by default (override default from NephronOptions)
-            as = ensureArg("--elasticUrl=", as);
-            var options = PipelineOptionsFactory.fromArgs(as).withValidation().as(BenchmarkOptions.class);
-            var pl = new ArrayList(paramList);
-            pl.removeAll(commonParameters);
-            resultConsumer.accept("=".repeat(30));
-            resultConsumer.accept(String.format("start pipeline run [%d/%d] at : %s", counter, paramLists.size(), Instant.now()));
-            resultConsumer.accept(String.format("varying pipeline arguments : %s", pl.stream().sorted().collect(Collectors.joining(" "))));
-            // The Apache beam flink runner automatically determines the jars / resources necessary for running the pipeline
-            // (cf. org.apache.beam.runners.flink.FlinkPipelineExecutionEnvironment#prepareFilesToStageForRemoteClusterExecution)
-            // -> this is done by considering involved class loaders
-            // -> in particular, the call stack is traversed to consider the class loaders of all classes on the call stack
-            //    (cf. nonapi.io.github.classgraph.classpath.ClassLoaderFinder)
-            // -> when the benchmark is run by maven then the maven exec plugin is on the call stack
-            // -> this would result in all maven classes being added as dependencies to the Flink job
-            // -> run the pipeline in a separate thread (thereby removing maven from the call stack)
-            var f = executor.submit(() -> {
-                try {
-                    new Benchmark(options, resultConsumer).run();
-                } catch (Exception e) {
-                    LOG.error("benchmark failed", e);
-                    throw new RuntimeException(e);
+        try {
+            for (var paramList : paramLists) {
+                executeCommand(cmdLineArgs.before);
+                var as = paramList.toArray(new String[0]);
+                as = ensureArg("--blockOnRun=false", as);
+                as = ensureArg("--runner=FlinkRunner", as);
+                // the benchmark may write to ES; disabled by default (override default from NephronOptions)
+                as = ensureArg("--elasticUrl=", as);
+                var options = PipelineOptionsFactory.fromArgs(as).withValidation().as(BenchmarkOptions.class);
+                var pl = new ArrayList(paramList);
+                pl.removeAll(commonParameters);
+                resultConsumer.accept("=".repeat(30));
+                resultConsumer.accept(String.format("start pipeline run [%d/%d] at : %s", counter, paramLists.size(), Instant.now()));
+                resultConsumer.accept(String.format("varying pipeline arguments : %s", pl.stream().sorted().collect(Collectors.joining(" "))));
+                // The Apache beam flink runner automatically determines the jars / resources necessary for running the pipeline
+                // (cf. org.apache.beam.runners.flink.FlinkPipelineExecutionEnvironment#prepareFilesToStageForRemoteClusterExecution)
+                // -> this is done by considering involved class loaders
+                // -> in particular, the call stack is traversed to consider the class loaders of all classes on the call stack
+                //    (cf. nonapi.io.github.classgraph.classpath.ClassLoaderFinder)
+                // -> when the benchmark is run by maven then the maven exec plugin is on the call stack
+                // -> this would result in all maven classes being added as dependencies to the Flink job
+                // -> run the pipeline in a separate thread (thereby removing maven from the call stack)
+                var f = executor.submit(() -> {
+                    try {
+                        new Benchmark(options, resultConsumer).run();
+                    } catch (Exception e) {
+                        LOG.error("benchmark failed", e);
+                        throw new RuntimeException(e);
+                    }
+                });
+                f.get();
+                executeCommand(cmdLineArgs.after);
+                if (counter < paramLists.size() && options.getSleepBetweenRunsMs() > 0) {
+                    Thread.sleep(options.getSleepBetweenRunsMs());
                 }
-            });
-            f.get();
-            executeCommand(cmdLineArgs.after);
-            if (counter < paramLists.size() && options.getSleepBetweenRunsMs() > 0) {
-                Thread.sleep(options.getSleepBetweenRunsMs());
+                counter++;
             }
-            counter++;
+        } finally {
+            executor.shutdown();
         }
-
-        executor.shutdown();
-
     }
 
     public static Set<String> commonParameters(List<List<String>> paramLists) {
@@ -180,6 +182,9 @@ public class Benchmark {
         }
     }
 
+    /**
+     * Adds an argument assignment to the given args array if that argument is not yet set.
+     */
     private static String[] ensureArg(String argAssignment, String[] args) {
         if (argValue(argAssignment, args) != null) {
             return args;
@@ -195,7 +200,7 @@ public class Benchmark {
         String leftHandSide = arg.substring(0, arg.indexOf('=') + 1);
         for (String a: args) {
             if (a.startsWith(leftHandSide)) {
-                return a.substring(leftHandSide.length() + 1);
+                return a.substring(leftHandSide.length());
             }
         }
         return null;

--- a/testing/src/main/resources/log4j2-testing.xml
+++ b/testing/src/main/resources/log4j2-testing.xml
@@ -33,6 +33,7 @@
         <Logger name="org.opennms.nephron.testing" level="DEBUG"/>
         <Logger name="org.opennms.nephron.cortex" level="WARN"/>
         <Logger name="org.opennms.nephron.cortex.CortexIo" level="WARN"/>
+        <Logger name="org.opennms.nephron.util.PaneAccumulator" level="WARN"/>
 
         <!--
             Set the level of org.opennms.nephron.cortex.CortexIo.write to TRACE in order to also store


### PR DESCRIPTION
Issue: https://issues.opennms.org/browse/NMS-13467

This PR

* adds the `PaneAccumulator` class that allows for an additional accumulation of result panes; if the commandline argument `--summaryAccumulationDelayMs` is non-zero then a `PaneAccumulator` is inserted into the pipeline

This PR contains some other minor commits that are a byproduct of the main work:

* The `Benchmark` application got some changes:
  * Cortex samples of different benchmark runs are differentiated by an additional label; this prevents "data conflicts" between different runs
  * The benchmark application now terminates properly in case of execution exceptions
  * A one-off error was fixed
* `CortexIo` got some changes:
  * additional counter metrics are provided that help to differentiate different kinds of Cortex response errors
  * the `orgId` configuration did not work
  * The implementation could be simplified by using Beam's `@Key` annotation
* `Pipeline` got a small change:
  * The `pane-` prefix was removed from `pane` label values
