### PR TITLE
no-jira: register NephronOptions and documentation tweaks

### DIFF
--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -12,8 +12,8 @@ OpenNMS {page-component-title} is an open source aggregation and streaming analy
 Large amounts of network flows data may result in slow generation of dashboard visualizations, particularly with longer time ranges (last day/week).
 A lot of calculations must occur to render these dashboards, which is challenging to do in real time with large volumes of flow data.
 
-Based on https://beam.apache.org/get-started/beam-overview/[Apache Beam], Nephron reads flows from Kafka, grouping elements into small windows (microbatches) by event time.
-It then processes all of the elements in the window together to calculate flow aggregates and top-N flows, and persists these aggregates in Elasticsearch, Cortex, or Kafka.
+Based on https://beam.apache.org/get-started/beam-overview/[Apache Beam], Nephron reads flows from Kafka, grouping elements by event time into windows of configurable length (e.g. 60 seconds; microbatches).
+It then accumulates all of flow elements in the window with matching attributes and aggregates the results further for example by hosts or applications. In order to even more reduce the amount of stored data, for some aggregations only the top-N results (with respect to traffic) are kept. Nephron can persist its results in Elasticsearch, Cortex, or Kafka.
 
 Queries from dashboards are significantly faster (under 10 seconds vs. 30 minutes on billions of documents), as the flow query engine renders top-N metrics from these stored pre-aggregated documents.
 Nephron also helps alleviate compute load on the Elasticsearch cluster, particularly for environments with large volumes of flows (>10,000 flows/sec).

--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -13,7 +13,9 @@ Large amounts of network flows data may result in slow generation of dashboard v
 A lot of calculations must occur to render these dashboards, which is challenging to do in real time with large volumes of flow data.
 
 Based on https://beam.apache.org/get-started/beam-overview/[Apache Beam], Nephron reads flows from Kafka, grouping elements by event time into windows of configurable length (e.g., 60 seconds; microbatches).
-It then accumulates all of flow elements in the window with matching attributes and aggregates the results further for example by hosts or applications. In order to even more reduce the amount of stored data, for some aggregations only the top-N results (with respect to traffic) are kept. Nephron can persist its results in Elasticsearch, Cortex, or Kafka.
+It then accumulates all of the flow elements in the window with matching attributes and aggregates the results further; for example, by hosts or applications. 
+In order to reduce the amount of stored data even more, for some aggregations only the top-N results (with respect to traffic) are kept. 
+Nephron can persist its results in Elasticsearch, Cortex, or Kafka.
 
 Queries from dashboards are significantly faster (under 10 seconds vs. 30 minutes on billions of documents), as the flow query engine renders top-N metrics from these stored pre-aggregated documents.
 Nephron also helps alleviate compute load on the Elasticsearch cluster, particularly for environments with large volumes of flows (>10,000 flows/sec).

--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -12,7 +12,7 @@ OpenNMS {page-component-title} is an open source aggregation and streaming analy
 Large amounts of network flows data may result in slow generation of dashboard visualizations, particularly with longer time ranges (last day/week).
 A lot of calculations must occur to render these dashboards, which is challenging to do in real time with large volumes of flow data.
 
-Based on https://beam.apache.org/get-started/beam-overview/[Apache Beam], Nephron reads flows from Kafka, grouping elements by event time into windows of configurable length (e.g. 60 seconds; microbatches).
+Based on https://beam.apache.org/get-started/beam-overview/[Apache Beam], Nephron reads flows from Kafka, grouping elements by event time into windows of configurable length (e.g., 60 seconds; microbatches).
 It then accumulates all of flow elements in the window with matching attributes and aggregates the results further for example by hosts or applications. In order to even more reduce the amount of stored data, for some aggregations only the top-N results (with respect to traffic) are kept. Nephron can persist its results in Elasticsearch, Cortex, or Kafka.
 
 Queries from dashboards are significantly faster (under 10 seconds vs. 30 minutes on billions of documents), as the flow query engine renders top-N metrics from these stored pre-aggregated documents.

--- a/docs/modules/configuration/pages/persistence.adoc
+++ b/docs/modules/configuration/pages/persistence.adoc
@@ -73,7 +73,7 @@ Stores the following metrics:
 | pane, direction, dscp, host
 |===
 
-The nodeId and ifIndex are encoded in metric names for some of the aggregations to reduce the production of label cardinalities.
+The nodeId and ifIndex are encoded in metric names for some of the aggregations to reduce the product of label cardinalities.
 
 Labels:
 

--- a/docs/modules/configuration/pages/persistence.adoc
+++ b/docs/modules/configuration/pages/persistence.adoc
@@ -73,7 +73,7 @@ Stores the following metrics:
 | pane, direction, dscp, host
 |===
 
-The nodeId and ifIndex are encoded in metric names for some of the aggregations to reduce the product of label cardinalities.
+The nodeId and ifIndex are encoded in metric names for some of the aggregations to reduce the product of label cardinalities to under a threshold determined by Cortex. 
 
 Labels:
 

--- a/docs/modules/configuration/pages/requirements.adoc
+++ b/docs/modules/configuration/pages/requirements.adoc
@@ -30,6 +30,6 @@ Run the following command to output a list of all Nephron-specific parameters:
 
 `java -jar <nephronDir>/assemblies/flink/target/nephron-flink-bundled-*.jar --help=NephronOptions`
 
-All Flink related parameters are output when executing:
+Run the following to output all Flink-related parameters:
 
 `java -jar <nephronDir>/assemblies/flink/target/nephron-flink-bundled-*.jar --help=FlinkPipelineOptions`

--- a/docs/modules/configuration/pages/requirements.adoc
+++ b/docs/modules/configuration/pages/requirements.adoc
@@ -24,12 +24,12 @@ After Nephron set up, you must do the following:
 == Run on Flink
 Once you set up your Flink cluster and size it to your flows volume, run the following to set up Nephron on Flink:
 
-`./bin/flink run --parallelism 1 --class org.opennms.nephron.Nephron assemblies/flink/target/nephron-flink-bundled-*.jar --runner=FlinkRunner --jobName=nephron --checkpointingInterval=600000 --autoCommit=false`
+`./bin/flink run --parallelism 1 --class org.opennms.nephron.Nephron <nephronDir>/assemblies/flink/target/nephron-flink-bundled-*.jar --runner=FlinkRunner --jobName=nephron --checkpointingInterval=600000 --autoCommit=false`
 
 A list of all Nephron specific parameters can be output by executing the following command:
 
-`java -jar assemblies/flink/target/nephron-flink-bundled-*.jar --help=NephronOptions`
+`java -jar <nephronDir>/assemblies/flink/target/nephron-flink-bundled-*.jar --help=NephronOptions`
 
 All Flink related parameters are output when executing:
 
-`java -jar assemblies/flink/target/nephron-flink-bundled-*.jar --help=FlinkPipelineOptions`
+`java -jar <nephronDir>/assemblies/flink/target/nephron-flink-bundled-*.jar --help=FlinkPipelineOptions`

--- a/docs/modules/configuration/pages/requirements.adoc
+++ b/docs/modules/configuration/pages/requirements.adoc
@@ -26,7 +26,7 @@ Once you set up your Flink cluster and size it to your flows volume, run the fol
 
 `./bin/flink run --parallelism 1 --class org.opennms.nephron.Nephron <nephronDir>/assemblies/flink/target/nephron-flink-bundled-*.jar --runner=FlinkRunner --jobName=nephron --checkpointingInterval=600000 --autoCommit=false`
 
-A list of all Nephron specific parameters can be output by executing the following command:
+Run the following command to output a list of all Nephron-specific parameters:
 
 `java -jar <nephronDir>/assemblies/flink/target/nephron-flink-bundled-*.jar --help=NephronOptions`
 

--- a/docs/modules/configuration/pages/requirements.adoc
+++ b/docs/modules/configuration/pages/requirements.adoc
@@ -1,5 +1,5 @@
 [[requirements]]
-= Requirements
+= Requirements and Running
 
 Make sure you have the following:
 
@@ -14,16 +14,22 @@ Make sure you have the following:
 * Kafka server with forwarder enabled (see *Operation>Flow Support>Scale Flow Processing with Sentinel>Set up Message Broker: Kafka* in the core docs)
 * A fast-caching DNS resolver if using reverse DNS
 
-[[flink]]
-== Run on Flink
-Once you set up your Flink cluster and size it to your flows volume, run the following to set up Nephron on Flink:
-
-`./bin/flink run --parallelism 1 --class org.opennms.nephron.Nephron /root/git/nephron/assemblies/flink/target/nephron-flink-bundled-*.jar --runner=FlinkRunner --jobName=nephron --checkpointingInterval=600000 --autoCommit=false`
-
 After Nephron set up, you must do the following:
 
  * xref:kafka.adoc#kafka-config[Configure Kafka]
  * xref:persistence.adoc#nephron-persistence[Configure persistence]
  * xref:monitor.adoc#nephron-monitor[Monitor Nephron]
 
+[[flink]]
+== Run on Flink
+Once you set up your Flink cluster and size it to your flows volume, run the following to set up Nephron on Flink:
 
+`./bin/flink run --parallelism 1 --class org.opennms.nephron.Nephron assemblies/flink/target/nephron-flink-bundled-*.jar --runner=FlinkRunner --jobName=nephron --checkpointingInterval=600000 --autoCommit=false`
+
+A list of all Nephron specific parameters can be output by executing the following command:
+
+`java -jar assemblies/flink/target/nephron-flink-bundled-*.jar --help=NephronOptions`
+
+All Flink related parameters are output when executing:
+
+`java -jar assemblies/flink/target/nephron-flink-bundled-*.jar --help=FlinkPipelineOptions`

--- a/main/src/main/java/org/opennms/nephron/Nephron.java
+++ b/main/src/main/java/org/opennms/nephron/Nephron.java
@@ -37,6 +37,7 @@ public class Nephron {
     }
 
     public static void main(String[] args) {
+        PipelineOptionsFactory.register(NephronOptions.class);
         final NephronOptions options =
                 PipelineOptionsFactory.fromArgs(args).withValidation().as(NephronOptions.class);
         runNephron(options);


### PR DESCRIPTION
This PR
* registers the `NephronOptions` with the `PipelineOptionsFactory`; this allows to output their documentation by the command line argument --help=NephronOptions
* includes some documentation tweaks